### PR TITLE
RGFBEALF7-23 [Update] job build with ubuntu v18.04 which should have glibc v2.27

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
     name: Build Windows amd64
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v2


### PR DESCRIPTION
rebuild binary with glibc <= v2.28